### PR TITLE
Use relative asset paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "start": "parcel index.html",
-    "build": "parcel build index.html"
+    "build": "parcel build --public-url . index.html"
   },
   "devDependencies": {
     "parcel-bundler": "^1.12.2"


### PR DESCRIPTION
This change allows the generated `dist/index.html` to be opened from the local filesystem, instead of having to run it on a server.