### PR TITLE
Add script for generating items.json from items.xml

### DIFF
--- a/scripts/generate-items.py
+++ b/scripts/generate-items.py
@@ -1,0 +1,14 @@
+import xml.etree.ElementTree as ET
+import json
+
+root = ET.parse('./items.xml').getroot()
+
+items = []
+
+for child in root:
+    item = { 'type': child.tag }
+    item.update(child.attrib)
+    items.append(item)
+
+with open('./items.json', 'w') as f:
+    json.dump(items, f, indent=4, sort_keys=True)


### PR DESCRIPTION
This script requires Isaac's `items.xml` file to be placed in the same directory as it, and it will output an `items.json` in the same directory.