### PR TITLE
Change color name in title to be colored

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -15,7 +15,11 @@
       <div class="page-title">
         <h1>Binding Of Isaac: Challenge Generator</h1>
       </div>
-      <div class="challenge-title" id="title"></div>
+      <div class="challenge-title">
+        <span id="title-adjective"></span>
+        <span id="title-colour"></span>
+        <span id="title-character"></span>
+      </div>
       <div class="container">
         <div class="rule">
           <div class="rule-type">

--- a/js/app.js
+++ b/js/app.js
@@ -10,13 +10,18 @@ const today = new Date();
 today.setUTCHours(0, 0, 0, 0);
 
 const seed = today.getTime();
-const playableCharacter = getRandomWithSeed(characters, seed);
-const endingRoom = getRandomWithSeed(rooms, seed);
-const title = `${getRandomWithSeed(adjectives, seed)}
-  ${getRandomWithSeed(colours, seed)}
-  ${playableCharacter}`;
+const [ playableCharacter ] = getRandomWithSeed(characters, seed);
+const [ endingRoom ] = getRandomWithSeed(rooms, seed);
+const [ colour ] = getRandomWithSeed(colours, seed);
 
-document.getElementById("title").textContent = title;
+document.getElementById("title-adjective").textContent = getRandomWithSeed(adjectives, seed);
+
+const titleColourElement = document.getElementById("title-colour");
+
+titleColourElement.style.color = colour.hex;
+titleColourElement.textContent = colour.name;
+
+document.getElementById("title-character").textContent = playableCharacter;
 document.getElementById("seed").textContent = seed;
 document.getElementById("character").textContent = playableCharacter;
 document.getElementById("starting-items").textContent = getRandomWithSeed(

--- a/json/colours.json
+++ b/json/colours.json
@@ -1,133 +1,502 @@
 [
-  "Almond",
-  "Apricot",
-  "Aquamarine",
-  "Asparagus",
-  "Atomic Tangerine",
-  "Banana Mania",
-  "Beaver",
-  "Bittersweet",
-  "Black",
-  "Blizzard Blue",
-  "Blue",
-  "Blue Bell",
-  "Blue Gray",
-  "Blue Green",
-  "Blue Violet",
-  "Blush",
-  "Brick Red",
-  "Brown",
-  "Burnt Orange",
-  "Burnt Sienna",
-  "Cadet Blue",
-  "Canary",
-  "Caribbean Green",
-  "Carnation Pink",
-  "Cerise",
-  "Cerulean",
-  "Chestnut",
-  "Copper",
-  "Cornflower",
-  "Cotton Candy",
-  "Dandelion",
-  "Denim",
-  "Desert Sand",
-  "Eggplant",
-  "Electric Lime",
-  "Fern",
-  "Forest Green",
-  "Fuchsia",
-  "Fuzzy Wuzzy",
-  "Gold",
-  "Goldenrod",
-  "Gray",
-  "Green",
-  "Green Blue",
-  "Green Yellow",
-  "Hot Magenta",
-  "Inchworm",
-  "Indigo",
-  "Jazzberry Jam",
-  "Jungle Green",
-  "Laser Lemon",
-  "Lavender",
-  "Lemon Yellow",
-  "Macaroni and Cheese",
-  "Magenta",
-  "Magic Mint",
-  "Mahogany",
-  "Maize",
-  "Manatee",
-  "Mango Tango",
-  "Maroon",
-  "Mauvelous",
-  "Melon",
-  "Midnight Blue",
-  "Mountain Meadow",
-  "Mulberry",
-  "Navy Blue",
-  "Neon Carrot",
-  "Olive Green",
-  "Orange",
-  "Orange Red",
-  "Orange Yellow",
-  "Orchid",
-  "Outer Space",
-  "Outrageous Orange",
-  "Pacific Blue",
-  "Peach",
-  "Periwinkle",
-  "Piggy Pink",
-  "Pine Green",
-  "Pink Flamingo",
-  "Pink Sherbet",
-  "Plum",
-  "Purple Heart",
-  "Purple Mountain's Majesty",
-  "Purple Pizzazz",
-  "Radical Red",
-  "Raw Sienna",
-  "Raw Umber",
-  "Razzle Dazzle Rose",
-  "Razzmatazz",
-  "Red",
-  "Red Orange",
-  "Red Violet",
-  "Robin's Egg Blue",
-  "Royal Purple",
-  "Salmon",
-  "Scarlet",
-  "Screamin' Green",
-  "Sea Green",
-  "Sepia",
-  "Shadow",
-  "Shamrock",
-  "Shocking Pink",
-  "Silver",
-  "Sky Blue",
-  "Spring Green",
-  "Sunglow",
-  "Sunset Orange",
-  "Tan",
-  "Teal Blue",
-  "Thistle",
-  "Tickle Me Pink",
-  "Timberwolf",
-  "Tropical Rain Forest",
-  "Tumbleweed",
-  "Turquoise Blue",
-  "Unmellow Yellow",
-  "Violet (Purple)",
-  "Violet Blue",
-  "Violet Red",
-  "Vivid Tangerine",
-  "Vivid Violet",
-  "White",
-  "Wild Blue Yonder",
-  "Wild Strawberry",
-  "Wild Watermelon",
-  "Wisteria",
-  "Yellow",
-  "Yellow Green",
-  "Yellow Orange"
+  {
+    "hex": "#EFDECD",
+    "name": "Almond"
+  },
+  {
+    "hex": "#CD9575",
+    "name": "Antique Brass"
+  },
+  {
+    "hex": "#FDD9B5",
+    "name": "Apricot"
+  },
+  {
+    "hex": "#78DBE2",
+    "name": "Aquamarine"
+  },
+  {
+    "hex": "#87A96B",
+    "name": "Asparagus"
+  },
+  {
+    "hex": "#FFA474",
+    "name": "Atomic Tangerine"
+  },
+  {
+    "hex": "#FAE7B5",
+    "name": "Banana Mania"
+  },
+  {
+    "hex": "#9F8170",
+    "name": "Beaver"
+  },
+  {
+    "hex": "#FD7C6E",
+    "name": "Bittersweet"
+  },
+  {
+    "hex": "#000000",
+    "name": "Black"
+  },
+  {
+    "hex": "#ACE5EE",
+    "name": "Blizzard Blue"
+  },
+  {
+    "hex": "#1F75FE",
+    "name": "Blue"
+  },
+  {
+    "hex": "#A2A2D0",
+    "name": "Blue Bell"
+  },
+  {
+    "hex": "#6699CC",
+    "name": "Blue Gray"
+  },
+  {
+    "hex": "#0D98BA",
+    "name": "Blue Green"
+  },
+  {
+    "hex": "#7366BD",
+    "name": "Blue Violet"
+  },
+  {
+    "hex": "#DE5D83",
+    "name": "Blush"
+  },
+  {
+    "hex": "#CB4154",
+    "name": "Brick Red"
+  },
+  {
+    "hex": "#B4674D",
+    "name": "Brown"
+  },
+  {
+    "hex": "#FF7F49",
+    "name": "Burnt Orange"
+  },
+  {
+    "hex": "#EA7E5D",
+    "name": "Burnt Sienna"
+  },
+  {
+    "hex": "#B0B7C6",
+    "name": "Cadet Blue"
+  },
+  {
+    "hex": "#FFFF99",
+    "name": "Canary"
+  },
+  {
+    "hex": "#1CD3A2",
+    "name": "Caribbean Green"
+  },
+  {
+    "hex": "#FFAACC",
+    "name": "Carnation Pink"
+  },
+  {
+    "hex": "#DD4492",
+    "name": "Cerise"
+  },
+  {
+    "hex": "#1DACD6",
+    "name": "Cerulean"
+  },
+  {
+    "hex": "#BC5D58",
+    "name": "Chestnut"
+  },
+  {
+    "hex": "#DD9475",
+    "name": "Copper"
+  },
+  {
+    "hex": "#9ACEEB",
+    "name": "Cornflower"
+  },
+  {
+    "hex": "#FFBCD9",
+    "name": "Cotton Candy"
+  },
+  {
+    "hex": "#FDDB6D",
+    "name": "Dandelion"
+  },
+  {
+    "hex": "#2B6CC4",
+    "name": "Denim"
+  },
+  {
+    "hex": "#EFCDB8",
+    "name": "Desert Sand"
+  },
+  {
+    "hex": "#6E5160",
+    "name": "Eggplant"
+  },
+  {
+    "hex": "#CEFF1D",
+    "name": "Electric Lime"
+  },
+  {
+    "hex": "#71BC78",
+    "name": "Fern"
+  },
+  {
+    "hex": "#6DAE81",
+    "name": "Forest Green"
+  },
+  {
+    "hex": "#C364C5",
+    "name": "Fuchsia"
+  },
+  {
+    "hex": "#CC6666",
+    "name": "Fuzzy Wuzzy"
+  },
+  {
+    "hex": "#E7C697",
+    "name": "Gold"
+  },
+  {
+    "hex": "#FCD975",
+    "name": "Goldenrod"
+  },
+  {
+    "hex": "#A8E4A0",
+    "name": "Granny Smith Apple"
+  },
+  {
+    "hex": "#95918C",
+    "name": "Gray"
+  },
+  {
+    "hex": "#1CAC78",
+    "name": "Green"
+  },
+  {
+    "hex": "#1164B4",
+    "name": "Green Blue"
+  },
+  {
+    "hex": "#FF1DCE",
+    "name": "Hot Magenta"
+  },
+  {
+    "hex": "#B2EC5D",
+    "name": "Inchworm"
+  },
+  {
+    "hex": "#5D76CB",
+    "name": "Indigo"
+  },
+  {
+    "hex": "#CA3767",
+    "name": "Jazzberry Jam"
+  },
+  {
+    "hex": "#3BB08F",
+    "name": "Jungle Green"
+  },
+  {
+    "hex": "#FCB4D5",
+    "name": "Lavender"
+  },
+  {
+    "hex": "#FFBD88",
+    "name": "Macaroni and Cheese"
+  },
+  {
+    "hex": "#F664AF",
+    "name": "Magenta"
+  },
+  {
+    "hex": "#AAF0D1",
+    "name": "Magic Mint"
+  },
+  {
+    "hex": "#CD4A4C",
+    "name": "Mahogany"
+  },
+  {
+    "hex": "#EDD19C",
+    "name": "Maize"
+  },
+  {
+    "hex": "#979AAA",
+    "name": "Manatee"
+  },
+  {
+    "hex": "#FF8243",
+    "name": "Mango Tango"
+  },
+  {
+    "hex": "#C8385A",
+    "name": "Maroon"
+  },
+  {
+    "hex": "#EF98AA",
+    "name": "Mauvelous"
+  },
+  {
+    "hex": "#FDBCB4",
+    "name": "Melon"
+  },
+  {
+    "hex": "#1A4876",
+    "name": "Midnight Blue"
+  },
+  {
+    "hex": "#30BA8F",
+    "name": "Mountain Meadow"
+  },
+  {
+    "hex": "#C54B8C",
+    "name": "Mulberry"
+  },
+  {
+    "hex": "#1974D2",
+    "name": "Navy Blue"
+  },
+  {
+    "hex": "#FFA343",
+    "name": "Neon Carrot"
+  },
+  {
+    "hex": "#BAB86C",
+    "name": "Olive Green"
+  },
+  {
+    "hex": "#FF7538",
+    "name": "Orange"
+  },
+  {
+    "hex": "#FF2B2B",
+    "name": "Orange Red"
+  },
+  {
+    "hex": "#F8D568",
+    "name": "Orange Yellow"
+  },
+  {
+    "hex": "#E6A8D7",
+    "name": "Orchid"
+  },
+  {
+    "hex": "#414A4C",
+    "name": "Outer Space"
+  },
+  {
+    "hex": "#FF6E4A",
+    "name": "Outrageous Orange"
+  },
+  {
+    "hex": "#1CA9C9",
+    "name": "Pacific Blue"
+  },
+  {
+    "hex": "#FFCFAB",
+    "name": "Peach"
+  },
+  {
+    "hex": "#C5D0E6",
+    "name": "Periwinkle"
+  },
+  {
+    "hex": "#FDDDE6",
+    "name": "Piggy Pink"
+  },
+  {
+    "hex": "#158078",
+    "name": "Pine Green"
+  },
+  {
+    "hex": "#FC74FD",
+    "name": "Pink Flamingo"
+  },
+  {
+    "hex": "#F78FA7",
+    "name": "Pink Sherbet"
+  },
+  {
+    "hex": "#8E4585",
+    "name": "Plum"
+  },
+  {
+    "hex": "#7442C8",
+    "name": "Purple Heart"
+  },
+  {
+    "hex": "#9D81BA",
+    "name": "Purple Mountain's Majesty"
+  },
+  {
+    "hex": "#FE4EDA",
+    "name": "Purple Pizzazz"
+  },
+  {
+    "hex": "#FF496C",
+    "name": "Radical Red"
+  },
+  {
+    "hex": "#D68A59",
+    "name": "Raw Sienna"
+  },
+  {
+    "hex": "#714B23",
+    "name": "Raw Umber"
+  },
+  {
+    "hex": "#FF48D0",
+    "name": "Razzle Dazzle Rose"
+  },
+  {
+    "hex": "#E3256B",
+    "name": "Razzmatazz"
+  },
+  {
+    "hex": "#EE204D",
+    "name": "Red"
+  },
+  {
+    "hex": "#FF5349",
+    "name": "Red Orange"
+  },
+  {
+    "hex": "#C0448F",
+    "name": "Red Violet"
+  },
+  {
+    "hex": "#1FCECB",
+    "name": "Robin's Egg Blue"
+  },
+  {
+    "hex": "#7851A9",
+    "name": "Royal Purple"
+  },
+  {
+    "hex": "#FF9BAA",
+    "name": "Salmon"
+  },
+  {
+    "hex": "#FC2847",
+    "name": "Scarlet"
+  },
+  {
+    "hex": "#76FF7A",
+    "name": "Screamin' Green"
+  },
+  {
+    "hex": "#9FE2BF",
+    "name": "Sea Green"
+  },
+  {
+    "hex": "#A5694F",
+    "name": "Sepia"
+  },
+  {
+    "hex": "#8A795D",
+    "name": "Shadow"
+  },
+  {
+    "hex": "#45CEA2",
+    "name": "Shamrock"
+  },
+  {
+    "hex": "#FB7EFD",
+    "name": "Shocking Pink"
+  },
+  {
+    "hex": "#CDC5C2",
+    "name": "Silver"
+  },
+  {
+    "hex": "#80DAEB",
+    "name": "Sky Blue"
+  },
+  {
+    "hex": "#ECEABE",
+    "name": "Spring Green"
+  },
+  {
+    "hex": "#FFCF48",
+    "name": "Sunglow"
+  },
+  {
+    "hex": "#FD5E53",
+    "name": "Sunset Orange"
+  },
+  {
+    "hex": "#FAA76C",
+    "name": "Tan"
+  },
+  {
+    "hex": "#18A7B5",
+    "name": "Teal Blue"
+  },
+  {
+    "hex": "#EBC7DF",
+    "name": "Thistle"
+  },
+  {
+    "hex": "#FC89AC",
+    "name": "Tickle Me Pink"
+  },
+  {
+    "hex": "#DBD7D2",
+    "name": "Timberwolf"
+  },
+  {
+    "hex": "#17806D",
+    "name": "Tropical Rain Forest"
+  },
+  {
+    "hex": "#DEAA88",
+    "name": "Tumbleweed"
+  },
+  {
+    "hex": "#77DDE7",
+    "name": "Turquoise Blue"
+  },
+  {
+    "hex": "#926EAE",
+    "name": "Violet (Purple)"
+  },
+  {
+    "hex": "#324AB2",
+    "name": "Violet Blue"
+  },
+  {
+    "hex": "#F75394",
+    "name": "Violet Red"
+  },
+  {
+    "hex": "#FFA089",
+    "name": "Vivid Tangerine"
+  },
+  {
+    "hex": "#8F509D",
+    "name": "Vivid Violet"
+  },
+  {
+    "hex": "#A2ADD0",
+    "name": "Wild Blue Yonder"
+  },
+  {
+    "hex": "#FF43A4",
+    "name": "Wild Strawberry"
+  },
+  {
+    "hex": "#FC6C85",
+    "name": "Wild Watermelon"
+  },
+  {
+    "hex": "#CDA4DE",
+    "name": "Wisteria"
+  }
 ]


### PR DESCRIPTION
This PR changes the color name in the challenge title to match the color being described by the name;

![Colored text](https://user-images.githubusercontent.com/1843197/58200739-61a63a80-7ccb-11e9-9bea-daa606a74531.png)

I have removed some of the brighter colors, as they couldn't be seen against the white background.

I'm not a fan of having three spans making up the title, but I can't see another (easy) way of doing it.

---

Source for list of colors: https://gist.github.com/jjdelc/1868136